### PR TITLE
Override GetDummyQuery in OracleConnectionManager

### DIFF
--- a/src/dbup-oracle/OracleConnectionManager.cs
+++ b/src/dbup-oracle/OracleConnectionManager.cs
@@ -12,6 +12,8 @@ namespace DbUp.Oracle
     {
         private readonly OracleCommandSplitter commandSplitter;
 
+        protected override string GetDummyQuery() => "select 1 from dual";
+
         /// <summary>
         /// Creates a new Oracle database connection manager.
         /// </summary>


### PR DESCRIPTION
Oracle requires "from dual" in any select statement. Thus, the statement used by TryConnect "select 1" fails with the `ORA-00923: FROM keyword not found where expected` exception as reported in [issue #5](https://github.com/DbUp/dbup-oracle/issues/5). 
To fix it, we override the `GetDummyQuery` used in the `TryConnect` method with "**select 1 from dual**" which is valid Oracle syntax.

Fixes #5 